### PR TITLE
Fix cors errors for google apps script

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,3 @@
+[functions]
+  directory = "netlify/functions"
+

--- a/netlify/functions/gas-proxy.js
+++ b/netlify/functions/gas-proxy.js
@@ -1,0 +1,50 @@
+const GAS_URL = process.env.GAS_URL || "https://script.google.com/macros/s/AKfycbxWk0l3SKqvIqxUlwmahj1gvRetMxBirfGCCCraEtGbnzE5fkmxYn92V1N1aqVZOLYh4w/exec";
+
+exports.handler = async (event) => {
+  const origin = event.headers.origin || "";
+  const allowedOrigins = [
+    "http://localhost:8888",
+    "http://localhost:5173",
+    "https://saadsiteportfolio.netlify.app",
+  ];
+  const corsOrigin = allowedOrigins.includes(origin) ? origin : "https://saadsiteportfolio.netlify.app";
+
+  const corsHeaders = {
+    "Access-Control-Allow-Origin": corsOrigin,
+    "Access-Control-Allow-Methods": "POST,OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type",
+    Vary: "Origin",
+  };
+
+  if (event.httpMethod === "OPTIONS") {
+    return { statusCode: 204, headers: corsHeaders, body: "" };
+  }
+
+  if (event.httpMethod !== "POST") {
+    return { statusCode: 405, headers: corsHeaders, body: "Method Not Allowed" };
+  }
+
+  try {
+    const upstream = await fetch(GAS_URL, {
+      method: "POST",
+      headers: { "Content-Type": event.headers["content-type"] || "application/json" },
+      body: event.body,
+    });
+
+    const text = await upstream.text();
+    const contentType = upstream.headers.get("content-type") || "text/plain";
+
+    return {
+      statusCode: upstream.status,
+      headers: { ...corsHeaders, "Content-Type": contentType },
+      body: text,
+    };
+  } catch (err) {
+    return {
+      statusCode: 502,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+      body: JSON.stringify({ error: "Upstream fetch failed" }),
+    };
+  }
+};
+

--- a/src/lib/upload.ts
+++ b/src/lib/upload.ts
@@ -17,10 +17,7 @@ async function fileToBase64(file: File): Promise<string> {
 }
 
 export async function uploadFileToAppsScript(file: File): Promise<UploadResponse> {
-  const endpoint = import.meta.env.VITE_APPS_SCRIPT_UPLOAD_URL;
-  if (!endpoint) {
-    throw new Error("Apps Script upload URL not configured. Set VITE_APPS_SCRIPT_UPLOAD_URL");
-  }
+  const endpoint = import.meta.env.VITE_UPLOAD_PROXY_URL || "/.netlify/functions/gas-proxy";
 
   const base64 = await fileToBase64(file);
 

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -5,6 +5,7 @@ interface ImportMetaEnv {
   readonly VITE_EMAILJS_SERVICE_ID: string
   readonly VITE_EMAILJS_TEMPLATE_ID: string
   readonly VITE_APPS_SCRIPT_UPLOAD_URL: string
+  readonly VITE_UPLOAD_PROXY_URL?: string
 }
 
 interface ImportMeta {


### PR DESCRIPTION
Add Netlify Function proxy and update frontend to resolve CORS errors with Google Apps Script uploads.

The previous direct calls from the frontend to Google Apps Script were blocked by CORS policy, as Apps Script does not provide the necessary `Access-Control-Allow-Origin` headers. This change routes the frontend requests through a Netlify Function, which acts as a same-origin proxy, allowing the browser to make the request successfully and the function to forward it server-to-server to Apps Script.

---
<a href="https://cursor.com/background-agent?bcId=bc-de971923-3abc-4e81-b7a7-dfd6fc674c1d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-de971923-3abc-4e81-b7a7-dfd6fc674c1d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

